### PR TITLE
Implement gas on/off events for replay viewer

### DIFF
--- a/Elmanager/Forms/ReplayViewer.Designer.cs
+++ b/Elmanager/Forms/ReplayViewer.Designer.cs
@@ -41,6 +41,8 @@ namespace Elmanager.Forms
             this.supervoltsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.turnsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.groundtouchesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gasOnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gasOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.playbackSpeedBar = new Elmanager.CustomControls.TrackBarMod();
             this.TabControl1 = new Elmanager.CustomControls.TabControlMod();
@@ -135,7 +137,9 @@ namespace Elmanager.Forms
             this.rightVoltsToolStripMenuItem,
             this.supervoltsToolStripMenuItem,
             this.turnsToolStripMenuItem,
-            this.groundtouchesToolStripMenuItem});
+            this.groundtouchesToolStripMenuItem,
+            this.gasOnToolStripMenuItem,
+            this.gasOffToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.Size = new System.Drawing.Size(157, 136);
             // 
@@ -182,6 +186,20 @@ namespace Elmanager.Forms
             this.groundtouchesToolStripMenuItem.Name = "groundtouchesToolStripMenuItem";
             this.groundtouchesToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
             this.groundtouchesToolStripMenuItem.Text = "Groundtouches";
+            // 
+            // gasOnToolStripMenuItem
+            // 
+            this.gasOnToolStripMenuItem.CheckOnClick = true;
+            this.gasOnToolStripMenuItem.Name = "gasOnToolStripMenuItem";
+            this.gasOnToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
+            this.gasOnToolStripMenuItem.Text = "Gas on (approx)";
+            // 
+            // gasOffToolStripMenuItem
+            // 
+            this.gasOffToolStripMenuItem.CheckOnClick = true;
+            this.gasOffToolStripMenuItem.Name = "gasOffToolStripMenuItem";
+            this.gasOffToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
+            this.gasOffToolStripMenuItem.Text = "Gas off (approx)";
             // 
             // toolTip1
             // 
@@ -895,6 +913,8 @@ namespace Elmanager.Forms
         private ToolStripMenuItem supervoltsToolStripMenuItem;
         private ToolStripMenuItem turnsToolStripMenuItem;
         private ToolStripMenuItem groundtouchesToolStripMenuItem;
+        private ToolStripMenuItem gasOnToolStripMenuItem;
+        private ToolStripMenuItem gasOffToolStripMenuItem;
         private System.ComponentModel.IContainer components;
         private ToolTip toolTip1;
         private Button button1;

--- a/Elmanager/Forms/ReplayViewer.cs
+++ b/Elmanager/Forms/ReplayViewer.cs
@@ -487,6 +487,10 @@ namespace Elmanager.Forms
                     typesToShow.Add(LogicalEventType.Turn);
                 if (groundtouchesToolStripMenuItem.Checked)
                     typesToShow.Add(LogicalEventType.GroundTouch);
+                if (gasOnToolStripMenuItem.Checked)
+                    typesToShow.Add(LogicalEventType.GasOn);
+                if (gasOffToolStripMenuItem.Checked)
+                    typesToShow.Add(LogicalEventType.GasOff);
                 var evs = _replayController.UpdateEvents(typesToShow);
                 var p = _replayController.GetSelectedPlayer();
                 Utils.PutEventsToList(p, EventListBox, p.Finished || p.FakeFinish, evs);

--- a/Elmanager/Player.cs
+++ b/Elmanager/Player.cs
@@ -79,9 +79,11 @@ namespace Elmanager
                 }
             }
 
+            var gas = new List<bool>();
             for (var i = 0; i < frameCount; i++)
             {
                 var dirData = rec.ReadByte();
+                gas.Add(dirData % 2 == 1);
                 _direction.Add(dirData % 4 < 2 ? Direction.Left : Direction.Right);
             }
 
@@ -254,6 +256,23 @@ namespace Elmanager
 
             if ((!Finished && !FakeFinish) || Time == 0)
                 Time = Math.Round(frameCount / 30.0, 3);
+            
+            // calculating gas events
+            bool gasOn = false;
+            for (int i = 0; i < frameCount; i++)
+            {
+                if (gas[i] == gasOn)
+                    continue;
+                
+                gasOn = gas[i];
+                var eventTime = Math.Round(i / 30.0, 3);
+                if (eventTime >= Time)
+                    break;
+                
+                Events.Add(new PlayerEvent<LogicalEventType>(gasOn ? LogicalEventType.GasOn : LogicalEventType.GasOff, eventTime));
+            }
+            
+            Events.Sort((a, b) => a.Time.CompareTo(b.Time));
         }
 
         private void ComputeTripAndTopSpeed()

--- a/Elmanager/Replay.cs
+++ b/Elmanager/Replay.cs
@@ -25,7 +25,9 @@ namespace Elmanager
         Turn,
         RightVolt,
         LeftVolt,
-        SuperVolt
+        SuperVolt,
+        GasOn,
+        GasOff
     }
 
     internal enum Direction

--- a/Elmanager/Utils.cs
+++ b/Elmanager/Utils.cs
@@ -140,6 +140,7 @@ namespace Elmanager
             int superVoltCounter = 0;
             int gtCounter = 0;
             int appleCounter = 0;
+            int gasCounter = 0;
             double lastEventTime = 0;
             listBox.Items.Clear();
             foreach (var e in selectedEvents)
@@ -171,6 +172,13 @@ namespace Elmanager
                     case LogicalEventType.GroundTouch:
                         gtCounter++;
                         strToAdd = "Touch " + gtCounter;
+                        break;
+                    case LogicalEventType.GasOn:
+                        gasCounter++;
+                        strToAdd = "Gas on " + gasCounter;
+                        break;
+                    case LogicalEventType.GasOff:
+                        strToAdd = "Gas off " + gasCounter;
                         break;
                     default:
                         throw new Exception("Unknown ReplayEventType.");


### PR DESCRIPTION
Closes #143
Extracts throttle info from rec file and adds corresponding events in Replay Viewer
Throttle info is stored differently compared to other events and has lower time precision (1 rec frame or 1/30s)
![image](https://user-images.githubusercontent.com/18223426/103140819-785d1080-46fc-11eb-9776-d977f995e58b.png)
Was not sure if separate context menu items are nessesary. Added for versatility